### PR TITLE
fix: Slackのsを大文字にした

### DIFF
--- a/_posts/link.md
+++ b/_posts/link.md
@@ -12,5 +12,5 @@ ogImage:
 
 - ・ [connpass](https://misokatsu-web.connpass.com/)
 - ・ [Twitter](https://twitter.com/misokatsu_web?t=5fKW5UQnjFSFj1gbUXjpCw&s=09)
-- ・ [slack](https://miso-katsu-web.slack.com/join/shared_invite/zt-nvsgen9i-mYzeIqLMz4R7Xw~apXuBgw#/shared-invite/email)
+- ・ [Slack](https://miso-katsu-web.slack.com/join/shared_invite/zt-nvsgen9i-mYzeIqLMz4R7Xw~apXuBgw#/shared-invite/email)
 - ・ [note](https://note.com/asashin227/m/m2726899db499)


### PR DESCRIPTION
リンク集のSlackのsを大文字にした